### PR TITLE
Implement Collision Feeder

### DIFF
--- a/Gmod/addons/trakpak3/lua/entities/tp3_collision_feeder.lua
+++ b/Gmod/addons/trakpak3/lua/entities/tp3_collision_feeder.lua
@@ -1,0 +1,43 @@
+DEFINE_BASECLASS("tp3_base_prop")
+ENT.PrintName = "Trakpak3 Collision Trigger"
+ENT.Author = "Xayrga"
+ENT.Purpose = "Collides with things"
+ENT.Instructions = "Place in Hammer"
+
+if SERVER then
+
+	ENT.KeyValueMap = {
+
+	}
+	
+ 
+	
+	 
+	function ENT:Initialize()
+		self:SetSolid(SOLID_BBOX)
+		self:SetNotSolid(true)
+		self:SetTrigger(true) 
+		self:SetCollisionGroup(COLLISION_GROUP_WORLD)
+	end	
+	
+	function ENT:StartTouch(...)
+		if (self.TouchRedirector and self.TouchRedirector.StartTouch) then 
+			self.TouchRedirector:StartTouch(...) 
+		end 
+	end 
+	
+	function ENT:EndTouch(...) 
+		if (self.TouchRedirector and self.TouchRedirector.EndTouch) then 
+			self.TouchRedirector:EndTouch(...) 
+		end 
+	end
+
+	function ENT:PlaceCollision(min, max) 
+		self:SetCollisionBoundsWS(min, max)
+	end
+	
+	function ENT:PlaceCollisionRelative(min, max)
+		self:SetCollisionBounds(min,max)
+	end 
+	
+end


### PR DESCRIPTION
Add a collision feeder, a proxy trigger to relay start and stop touch events without checking every prop on the map every tick.

Should stop this from lagging at higher prop counts. 
